### PR TITLE
Update text for the help tooltip

### DIFF
--- a/ui/src/components/SEARCH_BAR.tsx
+++ b/ui/src/components/SEARCH_BAR.tsx
@@ -12,11 +12,11 @@ function SEARCH_BAR() {
 
   var helpText = `
 
-    You can search by title, speaker, series, abstract, sponsor and keywords.
+    You can search by title, speaker, abstract, sponsor and keywords.
     
     The default search operator is AND.
     
-    If you want to search by multiple words, use | between words, ex. particle | physics
+    For an OR search, use | between words, ex. particle | physics
     
     For exact match, use double quotes, like this: "dark matter"
     `;


### PR DESCRIPTION
- Removed "series"
- Changed "If you want to search by multiple words, use | between words, ex. particle | physics"
to:
"For an OR search, use | between words, ex. particle | physics"