### PR TITLE
ui: play button on parts player moved to center

### DIFF
--- a/ui/src/routes/lecture.tsx
+++ b/ui/src/routes/lecture.tsx
@@ -4,7 +4,7 @@ import { Helmet } from "react-helmet";
 
 import { List, Row, Layout, Tabs, Typography } from "antd";
 import { DownloadOutlined } from "@ant-design/icons";
-import { Player } from "video-react";
+import { Player, BigPlayButton } from "video-react";
 import "video-react/dist/video-react.css";
 
 import AT_HEADER from "../components/AT_HEADER";
@@ -84,6 +84,7 @@ function LectureItem({ lecture }: { lecture: LectureModel }) {
             <Tabs.TabPane tab={`Part ${index + 1}`} key={`video_${index}`}>
               <div className="video-window">
                 <Player height={300} playsInline>
+                  <BigPlayButton position="center" />
                   <source src={video} />
                 </Player>
               </div>


### PR DESCRIPTION
* ref: cern-sis/cern-academic-training#57

<img width="1037" alt="Screenshot 2023-01-26 at 08 59 20" src="https://user-images.githubusercontent.com/55505399/214785061-003d881e-d84b-45f5-8678-d0f8ebfd60d3.png">
